### PR TITLE
Add full support for suspend functions and default values in kotlin

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -26,6 +26,8 @@ dependencies {
     testImplementation("org.mockito:mockito-core:5.8.0")
     testImplementation("org.mockito:mockito-junit-jupiter:5.8.0")
 
+    testImplementation("org.jetbrains.kotlin:kotlin-reflect:2.3.10")
+
     testImplementation("org.jetbrains:annotations:24.1.0")
     testAnnotationProcessor("org.jetbrains:annotations:24.1.0")
 }

--- a/core/src/main/java/studio/mevera/imperat/CommandParsingMode.java
+++ b/core/src/main/java/studio/mevera/imperat/CommandParsingMode.java
@@ -1,0 +1,6 @@
+package studio.mevera.imperat;
+
+public enum CommandParsingMode {
+    JAVA,
+    KOTLIN
+}

--- a/core/src/main/java/studio/mevera/imperat/ConfigBuilder.java
+++ b/core/src/main/java/studio/mevera/imperat/ConfigBuilder.java
@@ -1,6 +1,7 @@
 package studio.mevera.imperat;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import studio.mevera.imperat.annotations.base.AnnotationReplacer;
 import studio.mevera.imperat.annotations.base.InstanceFactory;
 import studio.mevera.imperat.command.AttachmentMode;
@@ -511,6 +512,18 @@ public abstract class ConfigBuilder<S extends Source, I extends Imperat<S>, B ex
     public B instanceFactory(InstanceFactory<S> instanceFactory) {
         config.setInstanceFactory(instanceFactory);
         return (B) this;
+    }
+
+    public void setCoroutineScope(@NotNull Object scope) {
+        config.setCoroutineScope(scope);
+    }
+
+    public @Nullable Object getCoroutineScope() {
+        return config.getCoroutineScope();
+    }
+
+    public boolean hasCoroutineScope() {
+        return config.hasCoroutineScope();
     }
 
     /**

--- a/core/src/main/java/studio/mevera/imperat/ConfigBuilder.java
+++ b/core/src/main/java/studio/mevera/imperat/ConfigBuilder.java
@@ -526,6 +526,15 @@ public abstract class ConfigBuilder<S extends Source, I extends Imperat<S>, B ex
         return config.hasCoroutineScope();
     }
 
+    public B setCommandParsingMode(CommandParsingMode mode) {
+        config.setCommandParsingMode(mode);
+        return (B) this;
+    }
+
+    public CommandParsingMode getCommandParsingMode() {
+        return config.getCommandParsingMode();
+    }
+
     /**
      * Builds and returns the final configuration object based on the provided settings and definitions
      * within the builder. This method finalizes the configuration and ensures all dependencies

--- a/core/src/main/java/studio/mevera/imperat/ConfigBuilder.java
+++ b/core/src/main/java/studio/mevera/imperat/ConfigBuilder.java
@@ -514,8 +514,9 @@ public abstract class ConfigBuilder<S extends Source, I extends Imperat<S>, B ex
         return (B) this;
     }
 
-    public void setCoroutineScope(@NotNull Object scope) {
+    public B setCoroutineScope(@NotNull Object scope) {
         config.setCoroutineScope(scope);
+        return (B) this;
     }
 
     public @Nullable Object getCoroutineScope() {

--- a/core/src/main/java/studio/mevera/imperat/ImperatConfig.java
+++ b/core/src/main/java/studio/mevera/imperat/ImperatConfig.java
@@ -373,12 +373,6 @@ public sealed interface ImperatConfig<S extends Source> extends
 
     CommandParsingMode getCommandParsingMode();
 
-    enum CommandParsingMode {
-        JAVA,
-        KOTLIN,
-        AUTO
-    }
-
     EventBus getEventBus();
 
     void setEventBus(EventBus eventBus);

--- a/core/src/main/java/studio/mevera/imperat/annotations/base/MethodCommandExecutor.java
+++ b/core/src/main/java/studio/mevera/imperat/annotations/base/MethodCommandExecutor.java
@@ -86,6 +86,10 @@ public class MethodCommandExecutor<S extends Source> implements CommandExecution
         return AnnotationHelper.loadParameterInstances(dispatcher, fullParameters, context.source(), context, method);
     }
 
+    public MethodElement getMethodElement() {
+        return method;
+    }
+
     public MethodCaller.BoundMethodCaller getBoundMethodCaller() {
         return boundMethodCaller;
     }

--- a/core/src/main/java/studio/mevera/imperat/annotations/base/element/kotlin_parsing_visitors.kt
+++ b/core/src/main/java/studio/mevera/imperat/annotations/base/element/kotlin_parsing_visitors.kt
@@ -199,7 +199,7 @@ internal abstract class AbstractKotlinCommandParsingVisitor<S : Source>(
             val args = super.prepareArguments(context)
             val paramMap = buildParamMap(args)
             if (isSuspend) {
-                coroutineScope!!.launch {
+                coroutineScope?.launch {
                     kFunction.callSuspendBy(paramMap)
                 }
             } else {

--- a/core/src/main/java/studio/mevera/imperat/annotations/base/element/kotlin_parsing_visitors.kt
+++ b/core/src/main/java/studio/mevera/imperat/annotations/base/element/kotlin_parsing_visitors.kt
@@ -199,7 +199,9 @@ internal abstract class AbstractKotlinCommandParsingVisitor<S : Source>(
             val args = super.prepareArguments(context)
             val paramMap = buildParamMap(args)
             if (isSuspend) {
-                coroutineScope?.launch {
+                val scope = coroutineScope
+                    ?: throw IllegalStateException("Suspend function found but no coroutine scope")
+                scope.launch {
                     val returned = kFunction.callSuspendBy(paramMap)
                     handleReturnValue(context, returned)
                 }

--- a/core/src/test/java/studio/mevera/imperat/tests/commands/KotlinDefaultCommand.kt
+++ b/core/src/test/java/studio/mevera/imperat/tests/commands/KotlinDefaultCommand.kt
@@ -1,0 +1,15 @@
+package studio.mevera.imperat.tests.commands
+
+import studio.mevera.imperat.annotations.Command
+import studio.mevera.imperat.annotations.Execute
+import studio.mevera.imperat.annotations.Named
+import studio.mevera.imperat.tests.TestSource
+
+@Command("kdef")
+class KotlinDefaultCommand {
+
+    @Execute
+    fun run(source: TestSource, @Named("input") input: String = "hello") {
+        source.reply("input=$input")
+    }
+}

--- a/core/src/test/java/studio/mevera/imperat/tests/kotlin/KotlinDefaultValuesTest.java
+++ b/core/src/test/java/studio/mevera/imperat/tests/kotlin/KotlinDefaultValuesTest.java
@@ -1,0 +1,54 @@
+package studio.mevera.imperat.tests.kotlin;
+
+import org.junit.jupiter.api.Test;
+import studio.mevera.imperat.ImperatConfig;
+import studio.mevera.imperat.context.ExecutionResult;
+import studio.mevera.imperat.tests.TestImperat;
+import studio.mevera.imperat.tests.TestImperatConfig;
+import studio.mevera.imperat.tests.TestSource;
+import studio.mevera.imperat.tests.commands.KotlinDefaultCommand;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class KotlinDefaultValuesTest {
+
+    private static ExecutionResult<TestSource> executeWithCapture(
+            TestImperat imperat,
+            String commandLine,
+            ByteArrayOutputStream out
+    ) {
+        TestSource source = new TestSource(new PrintStream(out));
+        return imperat.execute(source, commandLine);
+    }
+
+    @Test
+    void shouldUseKotlinDefaultWhenArgumentOmitted() {
+        TestImperat imperat = TestImperatConfig.builder()
+                .applyOnConfig(cfg -> cfg.setCommandParsingMode(ImperatConfig.CommandParsingMode.KOTLIN))
+                .build();
+        imperat.registerCommand(KotlinDefaultCommand.class);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ExecutionResult<TestSource> result = executeWithCapture(imperat, "kdef", out);
+
+        assertThat(result.hasFailed()).isFalse();
+        assertThat(out.toString()).contains("input=hello");
+    }
+
+    @Test
+    void shouldUseProvidedValueWhenArgumentPresent() {
+        TestImperat imperat = TestImperatConfig.builder()
+                .applyOnConfig(cfg -> cfg.setCommandParsingMode(ImperatConfig.CommandParsingMode.KOTLIN))
+                .build();
+        imperat.registerCommand(KotlinDefaultCommand.class);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ExecutionResult<TestSource> result = executeWithCapture(imperat, "kdef hi", out);
+
+        assertThat(result.hasFailed()).isFalse();
+        assertThat(out.toString()).contains("input=hi");
+    }
+}

--- a/core/src/test/java/studio/mevera/imperat/tests/kotlin/KotlinDefaultValuesTest.java
+++ b/core/src/test/java/studio/mevera/imperat/tests/kotlin/KotlinDefaultValuesTest.java
@@ -1,6 +1,7 @@
 package studio.mevera.imperat.tests.kotlin;
 
 import org.junit.jupiter.api.Test;
+import studio.mevera.imperat.CommandParsingMode;
 import studio.mevera.imperat.ImperatConfig;
 import studio.mevera.imperat.context.ExecutionResult;
 import studio.mevera.imperat.tests.TestImperat;
@@ -27,7 +28,7 @@ public class KotlinDefaultValuesTest {
     @Test
     void shouldUseKotlinDefaultWhenArgumentOmitted() {
         TestImperat imperat = TestImperatConfig.builder()
-                .applyOnConfig(cfg -> cfg.setCommandParsingMode(ImperatConfig.CommandParsingMode.KOTLIN))
+                .applyOnConfig(cfg -> cfg.setCommandParsingMode(CommandParsingMode.KOTLIN))
                 .build();
         imperat.registerCommand(KotlinDefaultCommand.class);
 
@@ -41,7 +42,7 @@ public class KotlinDefaultValuesTest {
     @Test
     void shouldUseProvidedValueWhenArgumentPresent() {
         TestImperat imperat = TestImperatConfig.builder()
-                .applyOnConfig(cfg -> cfg.setCommandParsingMode(ImperatConfig.CommandParsingMode.KOTLIN))
+                .applyOnConfig(cfg -> cfg.setCommandParsingMode(CommandParsingMode.KOTLIN))
                 .build();
         imperat.registerCommand(KotlinDefaultCommand.class);
 

--- a/core/src/test/java/studio/mevera/imperat/tests/kotlin/KotlinDefaultValuesTest.java
+++ b/core/src/test/java/studio/mevera/imperat/tests/kotlin/KotlinDefaultValuesTest.java
@@ -3,11 +3,15 @@ package studio.mevera.imperat.tests.kotlin;
 import org.junit.jupiter.api.Test;
 import studio.mevera.imperat.CommandParsingMode;
 import studio.mevera.imperat.ImperatConfig;
+import studio.mevera.imperat.annotations.base.element.MethodElement;
+import studio.mevera.imperat.command.returns.BaseReturnResolver;
+import studio.mevera.imperat.context.ExecutionContext;
 import studio.mevera.imperat.context.ExecutionResult;
 import studio.mevera.imperat.tests.TestImperat;
 import studio.mevera.imperat.tests.TestImperatConfig;
 import studio.mevera.imperat.tests.TestSource;
 import studio.mevera.imperat.tests.commands.KotlinDefaultCommand;
+import studio.mevera.imperat.tests.commands.KotlinReturnCommand;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -51,5 +55,27 @@ public class KotlinDefaultValuesTest {
 
         assertThat(result.hasFailed()).isFalse();
         assertThat(out.toString()).contains("input=hi");
+    }
+
+    @Test
+    void shouldHandleReturnValuesLikeMethodCommandExecutor() {
+        TestImperat imperat = TestImperatConfig.builder()
+                .applyOnConfig(cfg -> {
+                    cfg.setCommandParsingMode(CommandParsingMode.KOTLIN);
+                })
+                .returnResolver(String.class, new BaseReturnResolver<TestSource, String>(String.class) {
+                    @Override
+                    public void handle(ExecutionContext<TestSource> context, MethodElement method, String value) {
+                        context.source().reply("returned=" + value);
+                    }
+                })
+                .build();
+        imperat.registerCommand(KotlinReturnCommand.class);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ExecutionResult<TestSource> result = executeWithCapture(imperat, "kret", out);
+
+        assertThat(result.hasFailed()).isFalse();
+        assertThat(out.toString()).contains("returned=ok");
     }
 }


### PR DESCRIPTION
Fully tested and works with ReturnResolver API, but some stuff need to be done for the user to actually use it:

```kotlin
val imperat = BukkitImperat.builder(this)
            .setCoroutineScope(this)
            .setCommandParsingMode(CommandParsingMode.KOTLIN)
            .build()
```

1. Apply `CommandParsingMode` to KOTLIN as it's JAVA by default
2. for suspend functions, you must provide the coroutine scope via `ConfigBuilder#setCoroutineScope` or `ImperatConfig#setCoroutineScope`
3. Must have the required libraries implemented (for `coroutineScope` and `launch` as it's used internally):
```kotlin
// For suspend function support
implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
// Need at all times
implementation("org.jetbrains.kotlin:kotlin-reflect:2.3.10")
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selectable command parsing modes (Java and Kotlin)
  * Commands can use Kotlin default parameters and improved return-value handling
  * Added configuration option to set a coroutine scope

* **Tests**
  * Added tests covering Kotlin default parameter behavior and return-value resolution
<!-- end of auto-generated comment: release notes by coderabbit.ai -->