### PR TITLE
feat(autocompletion): implement configurable autocompletion factory

### DIFF
--- a/core/src/main/java/studio/mevera/imperat/ConfigBuilder.java
+++ b/core/src/main/java/studio/mevera/imperat/ConfigBuilder.java
@@ -6,6 +6,7 @@ import studio.mevera.imperat.annotations.base.InstanceFactory;
 import studio.mevera.imperat.command.CommandCoordinator;
 import studio.mevera.imperat.command.CommandPathway;
 import studio.mevera.imperat.command.ContextArgumentProviderFactory;
+import studio.mevera.imperat.command.suggestions.AutoCompleterFactory;
 import studio.mevera.imperat.command.arguments.type.ArgumentType;
 import studio.mevera.imperat.command.arguments.type.ArgumentTypeHandler;
 import studio.mevera.imperat.command.returns.ReturnResolver;
@@ -113,6 +114,18 @@ public abstract class ConfigBuilder<S extends CommandSource, I extends Imperat<S
      */
     public B contextFactory(ContextFactory<S> contextFactory) {
         config.setContextFactory(contextFactory);
+        return (B) this;
+    }
+
+    /**
+     * Sets the factory used to create an {@link studio.mevera.imperat.command.suggestions.AutoCompleter}
+     * for each registered command.
+     *
+     * @param factory the factory to use
+     * @return this builder instance for chaining
+     */
+    public B autoCompleterFactory(AutoCompleterFactory<S> factory) {
+        config.setAutoCompleterFactory(factory);
         return (B) this;
     }
 

--- a/core/src/main/java/studio/mevera/imperat/ImperatConfig.java
+++ b/core/src/main/java/studio/mevera/imperat/ImperatConfig.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.Nullable;
 import studio.mevera.imperat.annotations.base.AnnotationReplacer;
 import studio.mevera.imperat.annotations.base.InstanceFactory;
 import studio.mevera.imperat.annotations.base.element.ParameterElement;
+import studio.mevera.imperat.command.suggestions.AutoCompleterFactory;
 import studio.mevera.imperat.command.Command;
 import studio.mevera.imperat.command.CommandCoordinator;
 import studio.mevera.imperat.command.CommandPathway;
@@ -328,6 +329,20 @@ public sealed interface ImperatConfig<S extends CommandSource> extends ResolverR
      * @param factory the instance factory to set
      */
     void setInstanceFactory(InstanceFactory<S> factory);
+
+    /**
+     * @return the factory used to create an {@link studio.mevera.imperat.command.suggestions.AutoCompleter}
+     * for each command
+     */
+    AutoCompleterFactory<S> getAutoCompleterFactory();
+
+    /**
+     * Sets the factory used to create an {@link studio.mevera.imperat.command.suggestions.AutoCompleter}
+     * for each command.
+     *
+     * @param factory the factory to set
+     */
+    void setAutoCompleterFactory(AutoCompleterFactory<S> factory);
 
     /**
      * @return the default global command coordinator

--- a/core/src/main/java/studio/mevera/imperat/ImperatConfigImpl.java
+++ b/core/src/main/java/studio/mevera/imperat/ImperatConfigImpl.java
@@ -10,6 +10,8 @@ import studio.mevera.imperat.command.Command;
 import studio.mevera.imperat.command.CommandCoordinator;
 import studio.mevera.imperat.command.CommandPathway;
 import studio.mevera.imperat.command.ContextArgumentProviderFactory;
+import studio.mevera.imperat.command.suggestions.AutoCompleterFactory;
+import studio.mevera.imperat.command.suggestions.NativeAutoCompleterFactory;
 import studio.mevera.imperat.command.ContextArgumentProviderRegistry;
 import studio.mevera.imperat.command.ReturnResolverRegistry;
 import studio.mevera.imperat.command.SourceProviderRegistry;
@@ -62,6 +64,7 @@ final class ImperatConfigImpl<S extends CommandSource> implements ImperatConfig<
     private final Map<Class<? extends Throwable>, CommandExceptionHandler<?, S>> errorHandlers = new HashMap<>();
     private final Map<Class<?>, AnnotationReplacer<?>> annotationReplacerMap = new HashMap<>();
     private InstanceFactory<S> instanceFactory = InstanceFactory.defaultFactory();
+    private AutoCompleterFactory<S> autoCompleterFactory = new NativeAutoCompleterFactory<>(false);
     private @NotNull SuggestionProvider<S> defaultSuggestionProvider =
             (context, input) ->
                     Collections.emptyList();
@@ -556,6 +559,16 @@ final class ImperatConfigImpl<S extends CommandSource> implements ImperatConfig<
     @Override
     public void setInstanceFactory(InstanceFactory<S> factory) {
         this.instanceFactory = factory;
+    }
+
+    @Override
+    public AutoCompleterFactory<S> getAutoCompleterFactory() {
+        return autoCompleterFactory;
+    }
+
+    @Override
+    public void setAutoCompleterFactory(AutoCompleterFactory<S> factory) {
+        this.autoCompleterFactory = factory;
     }
 
     @Override

--- a/core/src/main/java/studio/mevera/imperat/command/CommandImpl.java
+++ b/core/src/main/java/studio/mevera/imperat/command/CommandImpl.java
@@ -83,7 +83,7 @@ final class CommandImpl<S extends CommandSource> implements Command<S> {
         this.position = position;
         this.name = name.toLowerCase();
         this.setDefaultPathwayWithValidation(imperat.config().getGlobalDefaultPathway().build(this));
-        this.autoCompleter = AutoCompleter.createNative(this);
+        this.autoCompleter = imperat.config().getAutoCompleterFactory().create(this);
         this.suggestionProvider = SuggestionProvider.forCommand(this);
         this.annotatedElement = annotatedElement;
         this.tree = CommandTree.create(imperat.config(), this);

--- a/core/src/main/java/studio/mevera/imperat/command/suggestions/AutoCompleterFactory.java
+++ b/core/src/main/java/studio/mevera/imperat/command/suggestions/AutoCompleterFactory.java
@@ -1,0 +1,16 @@
+package studio.mevera.imperat.command.suggestions;
+
+import studio.mevera.imperat.command.Command;
+import studio.mevera.imperat.context.CommandSource;
+
+/**
+ * Factory responsible for creating an {@link AutoCompleter} for a given command.
+ *
+ * @param <S> the command-source type
+ */
+@FunctionalInterface
+public interface AutoCompleterFactory<S extends CommandSource> {
+
+    AutoCompleter<S> create(Command<S> command);
+
+}

--- a/core/src/main/java/studio/mevera/imperat/command/suggestions/FuzzyAutoCompleter.java
+++ b/core/src/main/java/studio/mevera/imperat/command/suggestions/FuzzyAutoCompleter.java
@@ -1,0 +1,36 @@
+package studio.mevera.imperat.command.suggestions;
+
+import studio.mevera.imperat.command.Command;
+import studio.mevera.imperat.context.CommandSource;
+import studio.mevera.imperat.context.SuggestionContext;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * An {@link AutoCompleter} that applies case-insensitive substring matching instead of
+ * the native case-sensitive prefix filter. Typing "jojo" will surface "Ein_Jojo".
+ *
+ * @param <S> the command-source type
+ */
+public final class FuzzyAutoCompleter<S extends CommandSource> extends AutoCompleter<S> {
+
+    public FuzzyAutoCompleter(Command<S> command) {
+        super(command);
+    }
+
+    @Override
+    public CompletableFuture<List<String>> autoComplete(SuggestionContext<S> context) {
+        return CompletableFuture.supplyAsync(() -> {
+            List<String> all = command.tree().tabCompleteRaw(context);
+            String prefix = context.getArgToComplete().value();
+            if (prefix.isBlank()) {
+                return all;
+            }
+            String lower = prefix.toLowerCase();
+            return all.stream()
+                    .filter(s -> s.toLowerCase().contains(lower))
+                    .toList();
+        });
+    }
+}

--- a/core/src/main/java/studio/mevera/imperat/command/suggestions/NativeAutoCompleterFactory.java
+++ b/core/src/main/java/studio/mevera/imperat/command/suggestions/NativeAutoCompleterFactory.java
@@ -1,0 +1,29 @@
+package studio.mevera.imperat.command.suggestions;
+
+import studio.mevera.imperat.command.Command;
+import studio.mevera.imperat.context.CommandSource;
+
+/**
+ * Default {@link AutoCompleterFactory} that produces either a native (prefix-based)
+ * or fuzzy (substring-based) completer depending on the {@code useFuzzy} flag.
+ *
+ * @param <S> the command-source type
+ */
+public final class NativeAutoCompleterFactory<S extends CommandSource> implements AutoCompleterFactory<S> {
+
+    private boolean useFuzzy;
+
+    public NativeAutoCompleterFactory(boolean useFuzzy) {
+        this.useFuzzy = useFuzzy;
+    }
+
+    public NativeAutoCompleterFactory<S> useFuzzy(boolean useFuzzy) {
+        this.useFuzzy = useFuzzy;
+        return this;
+    }
+
+    @Override
+    public AutoCompleter<S> create(Command<S> command) {
+        return useFuzzy ? new FuzzyAutoCompleter<>(command) : AutoCompleter.createNative(command);
+    }
+}

--- a/core/src/main/java/studio/mevera/imperat/command/tree/CommandTree.java
+++ b/core/src/main/java/studio/mevera/imperat/command/tree/CommandTree.java
@@ -83,6 +83,18 @@ public interface CommandTree<S extends CommandSource> {
     );
 
     /**
+     * Returns the full list of tab-completion candidates without applying any prefix filter.
+     * Intended for use by custom {@link studio.mevera.imperat.command.suggestions.AutoCompleter}
+     * implementations that apply their own filtering strategy (e.g. fuzzy matching).
+     *
+     * @param context the suggestion context
+     * @return the unfiltered list of candidates, never null
+     */
+    @NotNull List<String> tabCompleteRaw(
+            @NotNull SuggestionContext<S> context
+    );
+
+    /**
      * Queries the help system to retrieve a set of help entries that match the specified criteria.
      *
      * <p>This method searches through available help entries and returns those that satisfy

--- a/core/src/main/java/studio/mevera/imperat/command/tree/StandardCommandTree.java
+++ b/core/src/main/java/studio/mevera/imperat/command/tree/StandardCommandTree.java
@@ -1673,6 +1673,32 @@ final class StandardCommandTree<S extends CommandSource> implements CommandTree<
                                    .toList();
     }
 
+    @Override
+    public @NotNull List<String> tabCompleteRaw(@NotNull SuggestionContext<S> context) {
+        if (!hasAutoCompletionPermission(context.source(), root)) {
+            return Collections.emptyList();
+        }
+
+        ensureNodeCaches();
+        if (hasBlankGapBeforeCursor(context)) {
+            return Collections.emptyList();
+        }
+
+        Map<Argument<S>, SuggestionProvider<S>> candidates = new LinkedHashMap<>();
+        collectMatchingChildren(root, 0, context, candidates);
+        collectRootOnlyFlagSuggestions(context, candidates);
+
+        List<String> list = new ArrayList<>();
+        for (var candidate : candidates.entrySet()) {
+            Argument<S> arg = candidate.getKey();
+            if (!hasAutoCompletionPermission(context.source(), arg)) {
+                continue;
+            }
+            list.addAll(candidate.getValue().provide(context, arg));
+        }
+        return list;
+    }
+
     private void collectRootOnlyFlagSuggestions(
             @NotNull SuggestionContext<S> context,
             @NotNull Map<Argument<S>, SuggestionProvider<S>> candidates


### PR DESCRIPTION
 CommandImpl hardcodes AutoCompleter.createNative(this), giving no way to swap the completion strategy. The native strategy applies a case-sensitive startsWith filter at the end, so typing "jojo" never surfaces
 "Ein_Jojo". The goal is to introduce a factory seam in ImperatConfig so users can plug in custom or fuzzy completion globally.

AI Summary of what was done:
```
  - AutoCompleterFactory<S> — new functional interface: one method create(Command<S>) → AutoCompleter<S>
  - NativeAutoCompleterFactory<S> — default factory; useFuzzy=false → native, useFuzzy=true → fuzzy
  - FuzzyAutoCompleter<S> — calls the new tabCompleteRaw to get the full unfiltered candidate list, then applies case-insensitive contains instead of startsWith
  - CommandTree — added tabCompleteRaw declaration
  - StandardCommandTree — implemented tabCompleteRaw (same as tabComplete minus the final prefix filter)
  - ImperatConfig / ImperatConfigImpl — added getAutoCompleterFactory() / setAutoCompleterFactory(), default is NativeAutoCompleterFactory(false)
  - CommandImpl:86 — uses factory from config instead of hardcoded createNative
  - ConfigBuilder — added autoCompleterFactory(...) fluent method

```